### PR TITLE
Evitar acceso a rutas públicas si el usuario ya está autenticado

### DIFF
--- a/webapp/src/app/app.component.ts
+++ b/webapp/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { AfterViewInit, Component, inject, OnInit } from '@angular/core';
 import { NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router, RouterModule } from '@angular/router';
 import { AuthService } from './auth/services/auth.service';
 import { LoadingSpinnerComponent } from "./shared/loading-spinner/loading-spinner.component";
@@ -9,7 +9,7 @@ import { LoadingSpinnerComponent } from "./shared/loading-spinner/loading-spinne
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
   title = 'webapp';
   
   isRouteLoading: boolean = false;
@@ -25,6 +25,13 @@ export class AppComponent {
         this.isRouteLoading = false;
       }
     });
+  }
+
+  ngAfterViewInit(): void {
+    const initialLoadingEl = document.getElementById('initial-loading');
+    if (initialLoadingEl) {
+      initialLoadingEl.style.display = 'none';
+    }
   }
 
 }

--- a/webapp/src/app/app.routes.ts
+++ b/webapp/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { LayoutComponent } from './layout/layout.component';
 export const routes: Routes = [
   {
     path: 'auth',
+    canActivate: [publicGuard],
     loadChildren: () => import('./auth/auth.routes'),
   },
   {

--- a/webapp/src/app/core/guards/public.guard.ts
+++ b/webapp/src/app/core/guards/public.guard.ts
@@ -7,16 +7,9 @@ import { map, of, catchError } from 'rxjs';
 export const publicGuard: CanActivateFn = (): any => {
   const authService = inject(AuthService);
   const router = inject(Router);
-
-  // Si el estado ya está cargado, usamos el valor actual, si no, verificamos la sesión
   if (authService.authState().loggedIn) {
     return router.createUrlTree(['/dashboard']);
   }
-
-  // Si no está logueado, pero no hay certeza, verificamos la sesión
-  return authService.verifySession().pipe(
-    map(() => router.createUrlTree(['/dashboard'])),
-    // Si la sesión no es válida, permite el acceso
-    catchError(() => of(true))
-  );
+  // Si no está logueado, permite el acceso a rutas públicas
+  return of(true);
 };

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -8,6 +8,26 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
+  <div
+    id="initial-loading"
+    class="fixed inset-0 bg-gray-50/80 flex items-center justify-center z-50"
+  >
+    <div class="w-16 h-16">
+      <svg
+        class="w-full h-full animate-spin"
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="64" height="64" rx="16" fill="#432dd7" />
+        <path
+          d="M20 26C20 20.4772 24.4772 16 30 16H34C39.5228 16 44 20.4772 44 26V30C44 31.0609 44.4214 32.0783 45.1716 32.8284L46 33.6569C46.7071 34.364 47 35.3137 47 36.2929V40C47 42.2091 45.2091 44 43 44H21C18.7909 44 17 42.2091 17 40V36.2929C17 35.3137 17.2929 34.364 18 33.6569L18.8284 32.8284C19.5786 32.0783 20 31.0609 20 30V26Z"
+          fill="white"
+        />
+        <circle cx="32" cy="48" r="4" fill="#ea37a7" />
+      </svg>
+    </div>
+  </div>
   <app-root></app-root>
 </body>
 </html>


### PR DESCRIPTION
Este PR soluciona el problema donde, tras iniciar sesión correctamente, el usuario aún podía navegar manualmente a /auth/login y volver a autenticarse, lo que causaba un comportamiento no deseado.

El problema original se solucionó parcialmente en el commit bf1224e, eliminando el publicGuard, pero eso causó que no existiera ningún bloqueo para prevenir el acceso a rutas públicas tras autenticarse.
Este cambio:
- Reintroduce el publicGuard, pero refactorizado para no hacer llamadas HTTP.
- Utiliza únicamente el estado interno authState del AuthService para determinar si el usuario ya está autenticado.
- Redirige automáticamente al usuario a /dashboard si intenta acceder a rutas como /auth/login o /auth/register estando logueado.
- Evita el bucle de redirecciones que ocurría cuando la sesión expiraba.